### PR TITLE
Alpine based ruby images.

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,22 +1,15 @@
 ARG MRI_VERSION
-FROM ruby:${MRI_VERSION}
+FROM ruby:${MRI_VERSION}-alpine
 
-LABEL maintainer=blambeau@enspirit.be
-
-ENV LANG C.UTF-8
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-RUN apt-get update -qq \
- && apt-get install -qq --no-install-recommends \
-    curl \
-    vim \
-    libsasl2-dev \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apk add --no-cache --virtual ffi-dependencies \
+   build-base\
+   libffi-dev\
+   curl\
+   bash
 
 # Add user
-RUN addgroup --gid 1000 --system app \
- && adduser --uid 1000 --system --gid 1000 app \
+RUN addgroup -g 1000 --system app \
+ && adduser --uid 1000 --system app app \
  && mkdir -p /home/app \
  && chown app:app -R /home/app
 
@@ -26,7 +19,7 @@ WORKDIR /home/app
 
 COPY . /tmp/startback
 RUN cd /tmp/startback && \
-    mkdir -p /tmp/startback/pkg && \
-    gem build -o pkg/startback-base.gem startback-base.gemspec && \
-    gem install pkg/startback-base.gem && \
-    rm -rf /tmp/startback
+    mkdir -p /tmp/startback/pkg
+   #  gem build -o pkg/startback-base.gem startback-base.gemspec && \
+   #  gem install pkg/startback-base.gem && \
+   #  rm -rf /tmp/startback

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,14 +1,6 @@
 FROM startback:base
 
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update -qq \
- && apt-get install -qq --no-install-recommends \
-    nodejs \
-    yarn \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apk add --update nodejs
 
 COPY . /tmp/startback
 RUN cd /tmp/startback && \


### PR DESCRIPTION
Trying to reduce the images size:

```
### New sizes:
startback                                       web                     7f601bc6c0e6   17 seconds ago   403MB
startback                                       engine                  579b736cea31   6 minutes ago    278MB
startback                                       api                     1f45398b16b2   7 minutes ago    278MB
startback                                       base                    66682851a54e   7 minutes ago    231MB
### Original sizes:
enspirit/startback                              web-0.14-ruby3.1        d70a09d9fb79   5 weeks ago      1.2GB
enspirit/startback                              engine-0.14-ruby3.1     fc8f68c4fb36   5 weeks ago      997MB
enspirit/startback                              api-0.14-ruby3.1        6a135f4e4c59   5 weeks ago      997MB
enspirit/startback                              base-0.14-ruby3.1       f29fd24e6424   5 weeks ago      997MB
ens
```